### PR TITLE
A set of mini ROMs and associated produced images for testing

### DIFF
--- a/tests/refimg/generate_img
+++ b/tests/refimg/generate_img
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This file is a placeholder to help understand what is going on
+# when an image is stale or missing. It should be replaced locally
+# by an alternate version on machines able to generate images (hot_rom).
+
+image_file="$2"
+rom_file="$1"
+
+echo "Missing/stale image: $2 is out of sync with $1."
+
+exit 1

--- a/tests/refimg/makefile
+++ b/tests/refimg/makefile
@@ -1,0 +1,50 @@
+ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+WORK_DIR?=$(ROOT_DIR)/.tmp
+
+all:
+
+define test_rule
+test_name:=$$(notdir $$(basename $$(basename $(1))))
+
+TESTS+=$$(test_name)
+
+$$(test_name):$(WORK_DIR)/$$(test_name).hash
+	@if [ -e "$(ROOT_DIR)/img/$$(test_name).png" ] \
+		&& cmp "$(WORK_DIR)/$$(test_name).hash" "$(ROOT_DIR)/img/$$(test_name).hash"; \
+	then \
+		echo "$$(test_name): nothing to do"; \
+	else \
+		echo "$$(test_name): generating"; \
+		$(ROOT_DIR)/generate_img "$(WORK_DIR)/$$(test_name).ihex" "$(ROOT_DIR)/img/$$(test_name).png" && \
+		cp $(WORK_DIR)/$$(test_name).hash $(ROOT_DIR)/img; \
+	fi
+
+endef
+
+$(foreach test_file,$(wildcard $(ROOT_DIR)/src/*.test.m4),$(eval $(call test_rule,$(test_file))))
+
+$(WORK_DIR)/%.s:$(ROOT_DIR)/src/%.test.m4 $(WORK_DIR)
+	m4 -I $(ROOT_DIR)/src $< > $@
+
+$(WORK_DIR)/%.bin:$(WORK_DIR)/%.s
+	z80asm -I $(ROOT_DIR)/src -o $@ $<
+
+$(WORK_DIR)/%.ihex:$(WORK_DIR)/%.bin
+	objcopy -I binary -O ihex --change-section-address .data=0x0000 $< $@
+
+$(WORK_DIR)/%.hash:$(WORK_DIR)/%.ihex
+	md5sum $< | cut -d' ' -f1 > $@
+
+all:$(TESTS)
+
+$(WORK_DIR):
+	mkdir $@
+
+clean:
+	rm -rf $(WORK_DIR)
+
+.PHONY:all clean $(TESTS)
+
+.NOTPARALLEL:$(TESTS)
+
+.NOTINTERMEDIATE:

--- a/tests/refimg/src/border_color_full_40_24_red.test.m4
+++ b/tests/refimg/src/border_color_full_40_24_red.test.m4
@@ -1,0 +1,18 @@
+include(`common.m4')
+	org	0
+
+	ld      hl, 8000h
+        ld      sp, hl
+
+NOP
+
+IND(`R_IND_TGS', `00h')
+IND(`R_IND_MAT', `01h')
+IND(`R_IND_PAT', `00h')
+IND(`R_IND_ROR', `00h')
+
+halt:
+	halt
+	jp	halt
+
+include 'common.s'

--- a/tests/refimg/src/common.m4
+++ b/tests/refimg/src/common.m4
@@ -1,0 +1,37 @@
+define(`WRITE', `dnl
+	  ; `$2->$1'
+	    ld  a, 0x20 | `$1'
+	    out (IO_ADDR), a
+	    ld  a, `$2'
+	    out (IO_DATA), a'dnl
+)dnl
+define(`IND', `dnl
+	; `$2->$1'
+WRITE(`0', `CMD_IND | $1')
+WRITE(`1 | XQR', `$2')
+	  call  wait_ready'dnl
+)dnl
+define(`KRFI', `dnl
+	; `KRFI C=$1 B=$2 A=$3'
+WRITE(`1', `$1')
+WRITE(`2', `$2')
+WRITE(`3', `$3')
+WRITE(`0 | XQR', `CMD_KRF | 1')
+	  call  wait_ready'dnl
+)dnl
+define(`OCTI', `dnl
+	; `OCTI D=$1'
+WRITE(`0', `CMD_OCT | 1')
+WRITE(`1 | XQR', `$1')
+	  call	wait_ready'dnl
+)dnl
+define(`INY', `dnl
+	; `INY'
+WRITE(`0 | XQR', `CMD_INY')
+	  call  wait_ready'dnl
+)dnl
+define(`NOP', `dnl
+	; `NOP'
+WRITE(`0 | XQR', `CMD_NOP')
+	  call  wait_ready'dnl
+)dnl

--- a/tests/refimg/src/common.s
+++ b/tests/refimg/src/common.s
@@ -1,0 +1,30 @@
+wait_ready:
+	ld	a, 20h
+	out	(IO_ADDR), a
+wait_ready_:
+	in	a, (IO_DATA)
+	or	a
+	jp	m, wait_ready_
+	ret
+
+IO_ADDR:	equ 8fh
+IO_DATA:	equ 0cfh
+
+R_IND_ROM:	equ 0h
+R_IND_TGS:	equ 1h
+R_IND_MAT:	equ 2h
+R_IND_PAT:	equ 3h
+R_IND_DOR:	equ 4h
+R_IND_ROR:	equ 7h
+
+R_X:		equ 7h
+R_Y:		equ 6h
+
+CMD_IND:	equ 80h
+CMD_KRF:	equ 00h
+CMD_OCT:	equ 30h
+CMD_INY:	equ 0b0h
+CMD_NOP:	equ 91h
+
+XQR:		equ 8h
+

--- a/tests/refimg/src/grid_40_24.test.m4
+++ b/tests/refimg/src/grid_40_24.test.m4
@@ -1,0 +1,69 @@
+include(`common.m4')
+	org	0
+
+	ld      hl, 8000h
+        ld      sp, hl
+
+NOP
+
+IND(`R_IND_TGS', `00h')
+IND(`R_IND_MAT', `0Eh')
+IND(`R_IND_PAT', `37h')
+IND(`R_IND_ROR', `08h')
+IND(`R_IND_DOR', `20h')
+
+WRITE(`R_Y', `20h')
+WRITE(`R_X', `0')
+
+	ld	hl, grid
+	ld	b, (hl)
+	inc	hl
+	ld	c, IO_DATA
+WRITE(`0', `CMD_OCT | 1')
+	ld	a, 20h | XQR | 1
+	out	(IO_ADDR), a
+loop:	outi
+	jr	nz, loop
+
+WRITE(`R_Y', `0')
+WRITE(`R_X', `0')
+	ld	b, 1
+	call	line
+
+WRITE(`R_Y', `8')
+WRITE(`R_X', `0')
+	ld	b, 25
+bulk:
+	call	line
+INY
+	dec	b
+	jr	nz, bulk
+
+halt:
+	halt
+	jp	halt
+
+line:
+KRFI(`0', `0a0h', `07h')
+	ld 	a, 20h
+	out	(IO_ADDR), a
+	in	a, (IO_DATA)
+	and	20h
+	jr	z, line
+	ret
+
+include 'common.s'
+
+grid:
+	db	grid_end - grid
+	db	0xaa, 0x00, 0x00, 0x00
+	db	0x55, 0x00, 0x00, 0x00
+	db	0xaa, 0x00, 0x00, 0x00
+	db	0x55, 0x00, 0x00, 0x00
+	db	0xaa, 0x00, 0x00, 0x00
+	db	0x55, 0x00, 0x00, 0x00
+	db	0xaa, 0x00, 0x00, 0x00
+	db	0x55, 0x00, 0x00, 0x00
+	db	0xaa, 0x00, 0x00, 0x00
+	db	0x55, 0x00, 0x00, 0x00
+grid_end:


### PR DESCRIPTION
# Goal

I propose to have a set of tiny programs that we can use as ROMs (at address 0) that produce an expected still image on display. We can then compare the output of a real VG5000µ with the output of the project.

# Current shortcomings

- The output of a physical VG5000µ is not trivial to capture with a pixel level precision (ie, the pixel width is slightly varying on a single scanline). Current ongoing work attempts to oversample and do "clock recovery".
- This work makes use of m4 for macro expansion; z80asm comes with its builtin macro system, which would probably be easier to use.
- Commit the reference images is going to make the repo large, which should be avoided. Maybe use a submodule for the img directory to make it optional ?
